### PR TITLE
Bump bb8 from 0.4 to 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bb8-memcached"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Daniel Dao <dqminh89@gmail.com>"]
 edition = "2018"
 readme = "README.md"
@@ -11,7 +11,7 @@ keywords = ["memcache", "memcached", "cache", "database", "async"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bb8 = "0.4"
+bb8 = "0.5"
 async-trait = "0.1"
 memcache-async = "^0.4.3"
 futures = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,12 +2,12 @@
 //!
 //! # Example
 //! ```
-//! use futures_util::future::join_all;
+//! use futures::future::join_all;
 //! use bb8_memcached::{bb8, MemcacheConnectionManager};
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     let manager = RedisConnectionManager::new("redis://localhost").unwrap();
+//!     let manager = MemcacheConnectionManager::new("tcp://localhost:11211").unwrap();
 //!     let pool = bb8::Pool::builder().build(manager).await.unwrap();
 //!
 //!     let mut handles = vec![];
@@ -19,8 +19,6 @@
 //!             let mut conn = pool.get().await.unwrap();
 //!
 //!             let version = conn.version().await.unwrap();
-//!
-//!             assert_eq!("VERSION 1.6.9", reply);
 //!         }));
 //!     }
 //!


### PR DESCRIPTION
I've bumped bb8 to 0.5 and tweaked a few things:
- Connection is no longer an Option<Connection> (nothing was changing it to None)
- Removed the MemcachePool abstraction since it doesn't provide much anymore. Now the adapter exposes exactly the same thing as the redis adapter.
- Added an example on how to use the library.

I could see someone that would like to use the MemcachePool::run method, but it can easily be achieved by using TryFutureExt::and_then. E.g.

```rust
use futures::future::TryFutureExt;

pool
  .get()
  .and_then(|mut conn| async move {
    conn.get("foo")
      .await
      .map(SoBytes)
      .map_err(bb8::RunError::User)
  })
  .await
```

Let me know what you think! Thanks!