### PR TITLE
Bump memcache-async to latest version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords = ["memcache", "memcached", "cache", "database", "async"]
 [dependencies]
 bb8 = "0.7"
 async-trait = "0.1"
-memcache-async = "^0.4.3"
+memcache-async = "^0.6"
 futures = "0.3"
 url = "2"
 tokio = { version = "1", features = ["rt",  "net", "sync", "time"] }


### PR DESCRIPTION
I want to use bb8-memcache, but I depend on new features from newer releases of memcache-async.