### PR TITLE
Add repository to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ readme = "README.md"
 license = "MIT"
 description = "async connection pool for memcached, based on bb8 and memcache-async"
 keywords = ["memcache", "memcached", "cache", "database", "async"]
+repository = "https://github.com/dqminh/bb8-memcached"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
This makes it easy to go from the crates's page on crates.io or docs.rs to the GitHub repo, which is helpful for would-be contributors.