### PR TITLE
Support get_prefix operation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.cfdata.org/stash/plat/dockerfiles/debian-buster-rustlang/master:1.53.0-1-1 AS builder
+COPY Cargo.toml Cargo.lock /build/
+COPY src /build/src
+WORKDIR /build
+CMD cargo test

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 ## License
 
 MIT
+
+## Testing
+
+Run `docker compose up --exit-code-from tests --build`

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,21 @@
+services:
+    tests:
+        build: .
+        volumes:
+          - unix-sockets:/tmp/:rw
+          - cargo-cache:/usr/local/cargo/registry
+    memcached-unix:
+        image: memcached
+        command: memcached -s /tmp/memcached.sock -a 777
+        volumes:
+            - unix-sockets:/tmp/:rw
+    memcached-tcp:
+        image: memcached
+        command: memcached
+        ports:
+            - "11211:11211"
+        command: memcached
+
+volumes:
+    unix-sockets: {}
+    cargo-cache: {}

--- a/src/client.rs
+++ b/src/client.rs
@@ -51,6 +51,18 @@ impl Connection {
         }
     }
 
+    /// Get up to `limit` keys which match the given prefix. Returns a HashMap from keys to found values. This is not part of the Memcached standard, but some servers implement it nonetheless. If `limit` is `None`, an unlimited number of results will be returned.
+    pub async fn get_prefix<'a, K: Display>(
+        &'a mut self,
+        key_prefix: &'a K,
+        limit: Option<usize>,
+    ) -> Result<HashMap<String, Vec<u8>>, io::Error> {
+        match self {
+            Connection::Unix(ref mut c) => c.get_prefix(key_prefix, limit).await,
+            Connection::Tcp(ref mut c) => c.get_prefix(key_prefix, limit).await,
+        }
+    }
+
     /// Returns values for multiple keys in a single call as a HashMap from keys to found values. If a key is not present in memcached it will be absent from returned map.
     pub async fn get_multi<'a, K: AsRef<[u8]>>(
         &'a mut self,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ mod test {
 
     #[tokio::test]
     async fn test_cache_get() {
-        let manager = MemcacheConnectionManager::new("tcp://localhost:11211").unwrap();
+        let manager = MemcacheConnectionManager::new("tcp://memcached-tcp:11211").unwrap();
         let pool = bb8::Pool::builder().build(manager).await.unwrap();
 
         let pool = pool.clone();
@@ -98,7 +98,7 @@ mod test {
 
     #[tokio::test]
     async fn test_cache_add_delete() {
-        let manager = MemcacheConnectionManager::new("tcp://localhost:11211").unwrap();
+        let manager = MemcacheConnectionManager::new("tcp://memcached-tcp:11211").unwrap();
         let pool = bb8::Pool::builder().build(manager).await.unwrap();
 
         let pool = pool.clone();


### PR DESCRIPTION
When I upgraded memcache-async to 0.6 to get the `get_prefix` method (see rev e9ee77bff54455a4f80928318dccc21e4405e2ad) I forgot to extend Connection to call the underlying `get_prefix` method.