### PR TITLE
Use docker compose for tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,5 @@
+FROM registry.cfdata.org/stash/plat/dockerfiles/debian-buster-rustlang/master:1.53.0-1-1 AS builder
+COPY Cargo.toml Cargo.lock /build/
+COPY src /build/src
+WORKDIR /build
+CMD cargo test

--- a/README.md
+++ b/README.md
@@ -5,3 +5,7 @@
 ## License
 
 MIT
+
+## Testing
+
+Run `docker compose up --exit-code-from tests --build`

--- a/compose.yml
+++ b/compose.yml
@@ -1,0 +1,21 @@
+services:
+    tests:
+        build: .
+        volumes:
+          - unix-sockets:/tmp/:rw
+          - cargo-cache:/usr/local/cargo/registry
+    memcached-unix:
+        image: memcached
+        command: memcached -s /tmp/memcached.sock -a 777
+        volumes:
+            - unix-sockets:/tmp/:rw
+    memcached-tcp:
+        image: memcached
+        command: memcached
+        ports:
+            - "11211:11211"
+        command: memcached
+
+volumes:
+    unix-sockets: {}
+    cargo-cache: {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@ mod test {
 
     #[tokio::test]
     async fn test_cache_get() {
-        let manager = MemcacheConnectionManager::new("tcp://localhost:11211").unwrap();
+        let manager = MemcacheConnectionManager::new("tcp://memcached-tcp:11211").unwrap();
         let pool = bb8::Pool::builder().build(manager).await.unwrap();
 
         let pool = pool.clone();
@@ -98,7 +98,7 @@ mod test {
 
     #[tokio::test]
     async fn test_cache_add_delete() {
-        let manager = MemcacheConnectionManager::new("tcp://localhost:11211").unwrap();
+        let manager = MemcacheConnectionManager::new("tcp://memcached-tcp:11211").unwrap();
         let pool = bb8::Pool::builder().build(manager).await.unwrap();
 
         let pool = pool.clone();


### PR DESCRIPTION
This way, contributors can test on any OS, without installing or deploying memcached. It also makes the tests more self-documenting, no more reading through the code to understand how to set up tests. Just run `docker compose up --exit-code-from tests --build`.