### PR TITLE
Update bb8 & memcache-async

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/dqminh/bb8-memcached"
 [dependencies]
 bb8 = "0.7"
 async-trait = "0.1"
-memcache-async = "^0.6"
+memcache-async = "^0.6.4"
 futures = "0.3"
 url = "2"
 tokio = { version = "1", features = ["rt",  "net", "sync", "time"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ repository = "https://github.com/dqminh/bb8-memcached"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-bb8 = "0.7"
+bb8 = "0.8"
 async-trait = "0.1"
 memcache-async = "^0.6.4"
 futures = "0.3"

--- a/src/client.rs
+++ b/src/client.rs
@@ -44,7 +44,7 @@ impl Connection {
     }
 
     /// Returns the value for given key as bytes. If the value doesn't exist, std::io::ErrorKind::NotFound is returned.
-    pub async fn get<'a, K: Display>(&'a mut self, key: &'a K) -> Result<Vec<u8>, io::Error> {
+    pub async fn get<'a, K: AsRef<[u8]>>(&'a mut self, key: &'a K) -> Result<Vec<u8>, io::Error> {
         match self {
             Connection::Unix(ref mut c) => c.get(key).await,
             Connection::Tcp(ref mut c) => c.get(key).await,
@@ -54,7 +54,7 @@ impl Connection {
     /// Returns values for multiple keys in a single call as a HashMap from keys to found values. If a key is not present in memcached it will be absent from returned map.
     pub async fn get_multi<'a, K: AsRef<[u8]>>(
         &'a mut self,
-        keys: &'a Vec<K>,
+        keys: &'a [K],
     ) -> Result<HashMap<String, Vec<u8>>, io::Error> {
         match self {
             Connection::Unix(ref mut c) => c.get_multi(keys).await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,10 +59,7 @@ impl bb8::ManageConnection for MemcacheConnectionManager {
         Connection::connect(&self.uri).await
     }
 
-    async fn is_valid(
-        &self,
-        conn: &mut bb8::PooledConnection<'_, Self>,
-    ) -> Result<(), Self::Error> {
+    async fn is_valid(&self, conn: &mut Self::Connection) -> Result<(), Self::Error> {
         conn.version().await.map(|_| ())
     }
 


### PR DESCRIPTION
# Update memcache-async to 0.6.4

memcache-async broke backwards compatibility by changing the signature
of the 'get' method (accepting a [u8] instead of a Display).
Bump the dependency to accept memcache-async >= 0.6.4, to prevent
breakage when using an older version.


# Update to bb8 0.8.0

Fix the signature for is_valid, following what was done
in the official libraries.
See https://github.com/djc/bb8/commit/eb5c1a9fd7c93bc60422955190a5bb59e5e037a8