### PR TITLE
Update memcached-async and add increment command

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ repository = "https://github.com/dqminh/bb8-memcached"
 [dependencies]
 bb8 = "0.8"
 async-trait = "0.1"
-memcache-async = "^0.6.4"
+memcache-async = "^0.8.0"
 futures = "0.3"
 url = "2"
 tokio = { version = "1", features = ["rt",  "net", "sync", "time"] }

--- a/src/client.rs
+++ b/src/client.rs
@@ -96,6 +96,18 @@ impl Connection {
         }
     }
 
+    /// Increment a value and return the updated value.
+    pub async fn increment<'a, K: AsRef<[u8]>>(
+        &'a mut self,
+        key: &'a K,
+        amount: u64,
+    ) -> Result<u64, io::Error> {
+        match self {
+            Connection::Unix(ref mut c) => c.increment(key, amount).await,
+            Connection::Tcp(ref mut c) => c.increment(key, amount).await,
+        }
+    }
+
     pub async fn version(&mut self) -> Result<String, io::Error> {
         match self {
             Connection::Unix(ref mut c) => c.version().await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -118,6 +118,21 @@ mod test {
     }
 
     #[tokio::test]
+    async fn test_increment() {
+        let manager = MemcacheConnectionManager::new("tcp://localhost:11211").unwrap();
+        let pool = bb8::Pool::builder().build(manager).await.unwrap();
+
+        let pool = pool.clone();
+        let mut conn = pool.get().await.unwrap();
+
+        assert!(conn.flush().await.is_ok());
+
+        let (key, val) = ("increment", "0");
+        assert!(conn.set(&key, val.as_bytes(), 0).await.is_ok());
+        assert_eq!(conn.increment(&key, 1).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
     async fn test_cache_unix_socket() {
         let manager = MemcacheConnectionManager::new("unix:/tmp/memcached.sock").unwrap();
         let pool = bb8::Pool::builder().build(manager).await.unwrap();


### PR DESCRIPTION
v0.7.0 of memcached-async added support for increment.
v0.8.0 adds some additional commands but I didn't implement those. See [release notes](https://github.com/vavrusa/memcache-async/blob/master/RELEASE_NOTES).

This PR updates memcached-async, adds the increment command and a test.